### PR TITLE
Add scene cleanup and animation cancellation

### DIFF
--- a/src/classes/Scene.js
+++ b/src/classes/Scene.js
@@ -17,6 +17,8 @@ export default class Scene {
 
     this.ambientLight = undefined;
     this.directionalLight = undefined;
+
+    this.resizeListener = null;
   }
 
   initialize() {
@@ -102,7 +104,8 @@ export default class Scene {
     this.scene.add(zAxisLine);
 
 
-    window.addEventListener('resize', () => this.onWindowResize(), false);
+    this.resizeListener = this.onWindowResize.bind(this);
+    window.addEventListener('resize', this.resizeListener, false);
   }
 
   animate() {
@@ -128,5 +131,15 @@ export default class Scene {
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(width, height);
     this.renderer.setPixelRatio(window.devicePixelRatio);
+  }
+
+  dispose() {
+    if (this.resizeListener) {
+      window.removeEventListener('resize', this.resizeListener, false);
+      this.resizeListener = null;
+    }
+    if (this.controls && typeof this.controls.dispose === 'function') {
+      this.controls.dispose();
+    }
   }
 }

--- a/src/components/Canvas/CanvasArea/CanvasArea.jsx
+++ b/src/components/Canvas/CanvasArea/CanvasArea.jsx
@@ -17,10 +17,17 @@ export default function CanvasArea({ latestModel,error }) {
 
     const newMixers = [];
     const clock = new THREE.Clock();
-    setupAnimationLoop(test, newMixers, clock);
+
+    const frameRef = { id: null };
+    setupAnimationLoop(test, newMixers, clock, frameRef);
 
     setSceneInstance(test);
     setMixers(newMixers);
+
+    return () => {
+      cancelAnimationFrame(frameRef.id);
+      test.dispose();
+    };
   }, []);
 
 

--- a/src/utils/ModelRenderUtils.js
+++ b/src/utils/ModelRenderUtils.js
@@ -82,8 +82,15 @@ export const loadFBXModel = (scene, path, position, scale) => {
  * @param {Array} mixers - Array of animation mixers.
  * @param {THREE.Clock} clock - Clock for delta time.
  */
-export const setupAnimationLoop = (test, mixers, clock) => {
-  requestAnimationFrame(() => setupAnimationLoop(test, mixers, clock));
+//
+// Sets up a recursive animation loop and stores the current frame id so it can
+// be cancelled later. The `frameIdRef` object should have an `id` property that
+// will be updated with the latest requestAnimationFrame identifier.
+//
+export const setupAnimationLoop = (test, mixers, clock, frameIdRef) => {
+  frameIdRef.id = requestAnimationFrame(() =>
+    setupAnimationLoop(test, mixers, clock, frameIdRef)
+  );
   const delta = clock.getDelta();
   mixers.forEach((mixer) => mixer.update(delta));
   test.render();


### PR DESCRIPTION
## Summary
- store resize listener in `Scene` and add `dispose` method
- track frame id in `setupAnimationLoop`
- cancel animation frames and dispose the scene from `CanvasArea`

## Testing
- `npm run lint` *(fails: eslint config issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847c27d03448331a6b774878a557613